### PR TITLE
Move navbar when toolbar is open

### DIFF
--- a/kloud51/static/css/app.css
+++ b/kloud51/static/css/app.css
@@ -69,6 +69,10 @@ hr[small] {
     margin: 0;
 }
 
+.cms-toolbar-expanded .navbar-fixed-top {
+    margin-top: 45px;
+}
+
 @media (min-width: 768px) {
     .navbar {
         height: 70px;


### PR DESCRIPTION
You will get:

![image](https://user-images.githubusercontent.com/4629328/33515292-949ca5d4-d77a-11e7-8224-e8e03e0ae694.png)

Instead of:

![image](https://user-images.githubusercontent.com/4629328/33515299-a3e9d1ec-d77a-11e7-8222-013dcaf6e9db.png)
